### PR TITLE
Alias the @user instance variable to @channel

### DIFF
--- a/lib/youtubearchiver/video.rb
+++ b/lib/youtubearchiver/video.rb
@@ -36,6 +36,7 @@ module YoutubeArchiver
     attr_reader :video_file
     attr_reader :made_for_kids
     attr_reader :channel
+    attr_reader :user
     attr_accessor :screenshot_file # written in hypatia
 
     def initialize(video_hash)
@@ -58,6 +59,7 @@ module YoutubeArchiver
       @video_file = download_video
       @made_for_kids = video_hash["status"]["madeForKids"]
       @channel = Channel.lookup(@channel_id).first
+      @user = @channel # Yes, a Youtube User is technically different than a YouTube channel, but we can ignore that to fit with our existing taxonomy
       @screenshot_file = nil
     end
 

--- a/test/video_test.rb
+++ b/test/video_test.rb
@@ -18,8 +18,9 @@ class VideoTest < MiniTest::Test
     assert_not youtube_video.live
     assert_equal youtube_video.duration, "PT10S"
     assert_equal youtube_video.language, "en-US"
-    assert_equal youtube_video.channel.id, "UCyPVt0WxkrpUXOVUq0Hqtxw"
     assert_not_nil youtube_video.channel
+    assert_equal youtube_video.channel.id, "UCyPVt0WxkrpUXOVUq0Hqtxw"
+    assert_equal youtube_video.channel, youtube_video.user
     assert_nil youtube_video.screenshot_file
 
     assert youtube_video.num_views.to_i > 40_000


### PR DESCRIPTION
This allows us to call `.user` on a media post object in Hypatia, even if we don't know its source. Users on YouTube are technically different than YouTube channels, but we don't actually care about what YouTube would refer to as a user. 

# Testing instructions
`rake`