### PR TITLE
Some miscellaneous updates 

### DIFF
--- a/lib/youtubearchiver.rb
+++ b/lib/youtubearchiver.rb
@@ -40,12 +40,12 @@ module YoutubeArchiver
 
   define_setting :temp_storage_location, "tmp/youtubearchiver"
 
-  def self.retrieve_media(url)
+  def self.retrieve_media(url, extension = nil)
     response = Typhoeus.get(url)
 
     # Get the file extension if it's in the file
-    stripped_url = url.split("?").first  # remove URL query params
-    extension = stripped_url.split(".").last
+    stripped_url = url.split("?").first
+    extension = stripped_url.split(".").last if extension.nil?
 
     # Do some basic checks so we just empty out if there's something weird in the file extension
     # that could do some harm.

--- a/lib/youtubearchiver.rb
+++ b/lib/youtubearchiver.rb
@@ -44,7 +44,9 @@ module YoutubeArchiver
     response = Typhoeus.get(url)
 
     # Get the file extension if it's in the file
-    extension = url.split(".").last
+    stripped_url = url.split("?").first  # remove URL query params
+    extension = stripped_url.split(".").last
+
     # Do some basic checks so we just empty out if there's something weird in the file extension
     # that could do some harm.
     unless extension.empty?

--- a/lib/youtubearchiver/channel.rb
+++ b/lib/youtubearchiver/channel.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "byebug"
 require "securerandom"
 
 module YoutubeArchiver
@@ -35,7 +34,7 @@ module YoutubeArchiver
       @subscriber_count = json_channel["statistics"]["subscriberCount"]
       @video_count = json_channel["statistics"]["videoCount"]
       @made_for_kids = json_channel["status"]["madeForKids"]
-      @channel_image_file = YoutubeArchiver.retrieve_media(json_channel["snippet"]["thumbnails"]["high"]["url"])
+      @channel_image_file = YoutubeArchiver.retrieve_media(json_channel["snippet"]["thumbnails"]["high"]["url"], "jpg")
     end
 
     def self.retrieve_data(ids)

--- a/lib/youtubearchiver/video.rb
+++ b/lib/youtubearchiver/video.rb
@@ -36,6 +36,7 @@ module YoutubeArchiver
     attr_reader :video_file
     attr_reader :made_for_kids
     attr_reader :channel
+    attr_reader :user
     attr_accessor :screenshot_file # written in hypatia
 
     def initialize(video_hash)
@@ -58,6 +59,7 @@ module YoutubeArchiver
       @video_file = download_video
       @made_for_kids = video_hash["status"]["madeForKids"]
       @channel = Channel.lookup(@channel_id).first
+      @user = @channel # Yes, a Youtube User is technically different than a YouTube channel, but we can ignore that to fit with our existing taxonomy
       @screenshot_file = nil
     end
 

--- a/lib/youtubearchiver/video.rb
+++ b/lib/youtubearchiver/video.rb
@@ -59,7 +59,7 @@ module YoutubeArchiver
       @video_file = download_video
       @made_for_kids = video_hash["status"]["madeForKids"]
       @channel = Channel.lookup(@channel_id).first
-      @user = @channel # Yes, a Youtube User is technically different than a YouTube channel, but we can ignore that to fit with our existing taxonomy
+      @user = @channel # Yes, a Youtube User is technically different than a YouTube channel, but we can ignore that.
       @screenshot_file = nil
     end
 

--- a/test/video_test.rb
+++ b/test/video_test.rb
@@ -18,8 +18,9 @@ class VideoTest < MiniTest::Test
     assert_not youtube_video.live
     assert_equal youtube_video.duration, "PT10S"
     assert_equal youtube_video.language, "en-US"
-    assert_equal youtube_video.channel.id, "UCyPVt0WxkrpUXOVUq0Hqtxw"
     assert_not_nil youtube_video.channel
+    assert_equal youtube_video.channel.id, "UCyPVt0WxkrpUXOVUq0Hqtxw"
+    assert_equal youtube_video.channel, youtube_video.user
     assert_nil youtube_video.screenshot_file
 
     assert youtube_video.num_views.to_i > 40_000

--- a/test/video_test.rb
+++ b/test/video_test.rb
@@ -42,6 +42,7 @@ class VideoTest < MiniTest::Test
   end
 
   def test_handles_live_youtube_videos
+    skip "need to find a new live video of reasonable length"
     youtube_video = YoutubeArchiver::Video.lookup("nDDzUyGvloE").first
 
     assert_instance_of YoutubeArchiver::Video, youtube_video


### PR DESCRIPTION
This PR contains tiny changes required for https://github.com/TechAndCheck/hypatia/pull/59

It 
1. Changes the `YoutubeArchiver.retrieve_media` function to accept a hardcoded extension. Unfortunately, YouTube's URLs for channel images don't contain file extension in them, so we need to construct them manually
2. Adds a `user` instance variable to `YoutubeArchiver::Video`. It aliases the `channel` instance variable, which we should maybe consider deprecating in the future. Technically YouTube channels aren't the same thing as YouTube users, but for our purposes, they might as well be. And using the `[x]User]` pattern in this gem would bring it into line with our other scraper gems
3. Ignores a test. A live video we used to scrape has been taken down. We need to find another short one, but I think we can do that later. 

# Testing instructions
`rake test`