### PR TITLE
Conver video duration to Integer 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1.1
+        ruby-version: 3.1.2
         bundler-cache: true
     - name: Lint with Rubocop
       run: bundle exec rubocop
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1.1
+        ruby-version: 3.1.2
         bundler-cache: true
     - name: Install yt-dlp
       run: python3 -m pip install -U yt-dlp

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby "3.1.1"
+ruby "3.1.2"
 
 source "https://rubygems.org"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
-    minitest (5.15.0)
+    minitest (5.16.3)
     nokogiri (1.13.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.3-x86_64-darwin)
@@ -128,7 +128,7 @@ DEPENDENCIES
   youtubearchiver!
 
 RUBY VERSION
-   ruby 3.1.1p18
+   ruby 3.1.2p20
 
 BUNDLED WITH
    2.3.3

--- a/lib/youtubearchiver/video.rb
+++ b/lib/youtubearchiver/video.rb
@@ -50,7 +50,7 @@ module YoutubeArchiver
       @title = video_hash["snippet"]["title"]
       @channel_id = video_hash["snippet"]["channelId"]
       @language = video_hash["snippet"]["defaultAudioLanguage"]
-      @duration = video_hash["contentDetails"]["duration"]
+      @duration = Video.convert_video_length_to_seconds(video_hash["contentDetails"]["duration"])
       @live = video_hash["snippet"]["liveBroadcastContent"] == "live"
       @num_views = video_hash["statistics"]["viewCount"]
       @num_likes = video_hash["statistics"]["likeCount"]
@@ -106,6 +106,16 @@ module YoutubeArchiver
       raise YoutubeArchiver::AuthorizationError, "Invalid response code #{response.code}" if response.code > 400
 
       response
+    end
+
+    # Convert a YouTube duration string to number of seconds
+    # A duration string of "PT0H4M32S" signifies a length of 4 minutes and 32 seconds
+    def self.convert_video_length_to_seconds(duration_string)
+      if /PT((\d+)H)?((\d+)M)?((\d+)S)?/ =~ duration_string  # Use regex to capture num_hours, num_minutes, num_seconds
+        $2.to_i * 3600 + $4.to_i * 60 + $6.to_i # To convert to seconds, sum(num_hours*3600, num_minutes*60, num_seconds*1)
+      else
+        0
+      end
     end
   end
 end

--- a/test/video_test.rb
+++ b/test/video_test.rb
@@ -19,7 +19,7 @@ class VideoTest < MiniTest::Test
     assert_equal youtube_video.duration, 10
     assert_equal youtube_video.language, "en-US"
     assert_not_nil youtube_video.channel
-    assert_equal youtube_video.channel.id, "UCyPVt0WxkrpUXOVUq0Hqtxw"
+    assert_equal "UCyPVt0WxkrpUXOVUq0Hqtxw", youtube_video.channel.id
     assert_equal youtube_video.channel, youtube_video.user
     assert_nil youtube_video.screenshot_file
 
@@ -38,12 +38,12 @@ class VideoTest < MiniTest::Test
     assert_not_nil youtube_video.title
 
     assert_not_nil youtube_video.channel
-    assert_equal youtube_video.channel.id, "UCWheC07UYzRWXsv9yUnZJFw"
+    assert_equal "UCWheC07UYzRWXsv9yUnZJFw", youtube_video.channel.id
   end
 
   def test_handles_live_youtube_videos
-    skip "need to find a new live video of reasonable length"
-    youtube_video = YoutubeArchiver::Video.lookup("nDDzUyGvloE").first
+    # skip "need to find a new live video of reasonable length"
+    youtube_video = YoutubeArchiver::Video.lookup("21X5lGlDOfg").first
 
     assert_instance_of YoutubeArchiver::Video, youtube_video
     assert youtube_video.live
@@ -51,7 +51,7 @@ class VideoTest < MiniTest::Test
     assert_nil youtube_video.video_file
 
     assert_not_nil youtube_video.channel
-    assert_equal youtube_video.channel.id, "UCGv9D6jI_5qb12RzoEU4aEA"
+    assert_equal "UCLA_DiR1FfKNvjuUpBHmylQ", youtube_video.channel.id
   end
 
   def test_raises_exception_for_unavailable_videos

--- a/test/video_test.rb
+++ b/test/video_test.rb
@@ -16,7 +16,7 @@ class VideoTest < MiniTest::Test
     assert_equal youtube_video.id, "T3UVKJsTz5g"
     assert_equal youtube_video.title, "Reviewing Injury Reserve's By the Time I Get to Phoenix in 10 seconds or less"
     assert_not youtube_video.live
-    assert_equal youtube_video.duration, "PT10S"
+    assert_equal youtube_video.duration, 10
     assert_equal youtube_video.language, "en-US"
     assert_not_nil youtube_video.channel
     assert_equal youtube_video.channel.id, "UCyPVt0WxkrpUXOVUq0Hqtxw"


### PR DESCRIPTION
We used to this in Zenodotus, but that didn't make any sense. We should send Zenodotus the data it needs in the format it needs

Addresses https://github.com/TechAndCheck/zenodotus/issues/341
## Testing instructions
`rake`

